### PR TITLE
Change in post.html

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,7 +9,7 @@ layout: default
 
 {{ content }}
 
-{{ if site.related_posts }}
+{% if site.related_posts %}
 	<div id="posts">
 		<h3>See also...</h3>
 
@@ -18,7 +18,7 @@ layout: default
 		{% endfor %}
 	</div>
 
-{{ endif }}
+{% endif %}
 
 </div>
 


### PR DESCRIPTION
While using Jekyll 3.7.3 a Liquid Syntax Error was thrown at generation.
Found that invalid Liquid Markup Tag Type caused it.
Here is the proposed Change.